### PR TITLE
feat: add location navigation to browse disaster tiles

### DIFF
--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Info, MapPin } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, Info, MapPin } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -7,11 +7,20 @@ import {
     type MapPolygon,
 } from "@components/map/types";
 
+interface DisasterLocation {
+    imagePairId: string;
+    centroid: { lat: number; lng: number };
+    count: number;
+}
+
 interface DashboardSidebarProps {
     isOpen: boolean;
     onClose: () => void;
     onDisasterInfoClick?: () => void;
     polygons?: MapPolygon[];
+    disasterLocations?: DisasterLocation[];
+    currentLocationIndex?: number;
+    onLocationNavigate?: (index: number) => void;
 }
 
 const DISASTERS = [
@@ -61,6 +70,9 @@ const DashboardSidebar = ({
     onClose,
     onDisasterInfoClick,
     polygons = [],
+    disasterLocations = [],
+    currentLocationIndex = 0,
+    onLocationNavigate,
 }: DashboardSidebarProps) => {
     const [selectedDisaster, setSelectedDisaster] = useState(DISASTERS[0].id);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -213,6 +225,62 @@ const DashboardSidebar = ({
                             </li>
                         </ul>
                     </nav>
+
+                    {/* Location navigation */}
+                    {disasterLocations.length > 0 && (
+                        <div className="border-b border-slate-200 px-4 py-3">
+                            <h3 className="mb-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                                Locations ({disasterLocations.length} tiles)
+                            </h3>
+                            <div className="mb-2 flex items-center justify-between">
+                                <button
+                                    type="button"
+                                    className="grid h-7 w-7 place-items-center rounded-lg
+                                               text-slate-600 transition hover:bg-slate-100
+                                               disabled:opacity-40 disabled:pointer-events-none"
+                                    disabled={currentLocationIndex <= 0}
+                                    onClick={() => onLocationNavigate?.(currentLocationIndex - 1)}
+                                    aria-label="Previous location"
+                                >
+                                    <ChevronLeft className="h-4 w-4" />
+                                </button>
+                                <span className="text-sm font-medium text-slate-700">
+                                    {currentLocationIndex + 1} / {disasterLocations.length}
+                                </span>
+                                <button
+                                    type="button"
+                                    className="grid h-7 w-7 place-items-center rounded-lg
+                                               text-slate-600 transition hover:bg-slate-100
+                                               disabled:opacity-40 disabled:pointer-events-none"
+                                    disabled={currentLocationIndex >= disasterLocations.length - 1}
+                                    onClick={() => onLocationNavigate?.(currentLocationIndex + 1)}
+                                    aria-label="Next location"
+                                >
+                                    <ChevronRight className="h-4 w-4" />
+                                </button>
+                            </div>
+                            <ul className="max-h-48 space-y-0.5 overflow-y-auto">
+                                {disasterLocations.map((loc, i) => (
+                                    <li key={loc.imagePairId}>
+                                        <button
+                                            type="button"
+                                            className={`w-full rounded-md px-3 py-1.5 text-left text-sm transition ${
+                                                i === currentLocationIndex
+                                                    ? "bg-blue-50 font-semibold text-blue-700"
+                                                    : "text-slate-700 hover:bg-slate-100"
+                                            }`}
+                                            onClick={() => onLocationNavigate?.(i)}
+                                        >
+                                            Tile {i + 1}
+                                            <span className="ml-1 text-xs text-slate-400">
+                                                ({loc.count} features)
+                                            </span>
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
 
                     {/* Quick stats */}
                     {polygons.length > 0 && (

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -242,6 +242,25 @@ const ViewportWatcher = ({ onViewportChange }: ViewportWatcherProps) => {
     return null;
 };
 
+const FlyToHandler = ({ target }: { target: { lat: number; lng: number } | null }) => {
+    const map = useMap();
+    const prevTarget = useRef<{ lat: number; lng: number } | null>(null);
+
+    useEffect(() => {
+        if (
+            !target ||
+            (prevTarget.current &&
+                prevTarget.current.lat === target.lat &&
+                prevTarget.current.lng === target.lng)
+        )
+            return;
+        prevTarget.current = target;
+        map.flyTo([target.lat, target.lng], 17, { duration: 1.5 });
+    }, [map, target]);
+
+    return null;
+};
+
 const PolygonLayer = ({ polygons }: { polygons: MapPolygon[] }) => {
     if (polygons.length === 0) return null;
 
@@ -302,6 +321,7 @@ interface MapViewProps {
     polygons?: MapPolygon[];
     onViewportChange?: (bbox: ViewportBBox) => void;
     disablePolygons?: boolean;
+    flyTarget?: { lat: number; lng: number } | null;
 }
 
 const MapView = ({
@@ -310,6 +330,7 @@ const MapView = ({
     polygons = [],
     onViewportChange,
     disablePolygons = false,
+    flyTarget = null,
 }: MapViewProps) => {
     const polygonsToRender = disablePolygons ? [] : polygons;
     const [bbox, setBbox] = useState<ViewportBBox | null>(null);
@@ -420,6 +441,7 @@ const MapView = ({
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
             <ViewportWatcher onViewportChange={handleViewportChange} />
+            <FlyToHandler target={flyTarget} />
             {visibleOverlays.map((overlay) => (
                 <ImageOverlay
                     key={`${overlay.id}-${overlay.url}`}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import ChatDock from "@components/chat/ChatDock";
 import { getChatRuntimeConfig } from "@components/chat/config";
@@ -29,6 +29,12 @@ type GeoJsonFeature = {
 };
 
 type PolygonRing = [number, number][];
+
+interface DisasterLocation {
+    imagePairId: string;
+    centroid: { lat: number; lng: number };
+    count: number;
+}
 
 const toLatLng = ([lng, lat]: [number, number]) => [lat, lng] as [number, number];
 
@@ -135,6 +141,9 @@ const Dashboard = () => {
     );
     const [polygons, setPolygons] = useState<MapPolygon[]>([]);
     const [viewport, setViewport] = useState<ViewportBBox | null>(null);
+    const [disasterLocations, setDisasterLocations] = useState<DisasterLocation[]>([]);
+    const [currentLocationIndex, setCurrentLocationIndex] = useState(0);
+    const [flyTarget, setFlyTarget] = useState<{ lat: number; lng: number } | null>(null);
 
     useEffect(() => {
         if (!viewport) return;
@@ -164,6 +173,56 @@ const Dashboard = () => {
         return () => controller.abort();
     }, [viewport]);
 
+    useEffect(() => {
+        const { apiBaseUrl } = getChatRuntimeConfig();
+        const base = apiBaseUrl || API_BASE_FALLBACK;
+        const params = new URLSearchParams({
+            min_lng: "-80.0",
+            min_lat: "33.0",
+            max_lng: "-77.0",
+            max_lat: "35.5",
+            limit: "10000",
+        });
+        const url = `${base.replace(/\/+$/, "")}/locations?${params.toString()}`;
+        const controller = new AbortController();
+
+        fetch(url, { signal: controller.signal })
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+            .then((data: { features?: ApiLocationFeature[] }) => {
+                const byPair = new Map<string, { lats: number[]; lngs: number[]; count: number }>();
+                for (const f of data.features ?? []) {
+                    const pairId = f.image_pair_id;
+                    const lat = f.centroid?.lat;
+                    const lng = f.centroid?.lng;
+                    if (!pairId || typeof lat !== "number" || typeof lng !== "number") continue;
+                    const entry = byPair.get(pairId) ?? { lats: [], lngs: [], count: 0 };
+                    entry.lats.push(lat);
+                    entry.lngs.push(lng);
+                    entry.count += 1;
+                    byPair.set(pairId, entry);
+                }
+                const locations: DisasterLocation[] = [];
+                for (const [imagePairId, entry] of byPair) {
+                    const avgLat = entry.lats.reduce((a, b) => a + b, 0) / entry.lats.length;
+                    const avgLng = entry.lngs.reduce((a, b) => a + b, 0) / entry.lngs.length;
+                    locations.push({ imagePairId, centroid: { lat: avgLat, lng: avgLng }, count: entry.count });
+                }
+                setDisasterLocations(locations);
+            })
+            .catch((error) => {
+                if (controller.signal.aborted) return;
+                console.error("Failed to fetch disaster locations:", error);
+            });
+
+        return () => controller.abort();
+    }, []);
+
+    const handleLocationNavigate = useCallback((index: number) => {
+        if (index < 0 || index >= disasterLocations.length) return;
+        setCurrentLocationIndex(index);
+        setFlyTarget({ ...disasterLocations[index].centroid });
+    }, [disasterLocations]);
+
     const visiblePolygons = polygons.filter((polygon) => {
         const key = normalizeClassification(polygon.classification ?? null);
         return locationToggles[key];
@@ -186,6 +245,7 @@ const Dashboard = () => {
                         polygons={visiblePolygons}
                         onViewportChange={setViewport}
                         disablePolygons={disableAllArtifacts}
+                        flyTarget={flyTarget}
                     />
                 </ErrorBoundary>
             </div>
@@ -215,6 +275,9 @@ const Dashboard = () => {
                     setIsDisasterInfoOpen(true);
                 }}
                 polygons={polygons}
+                disasterLocations={disasterLocations}
+                currentLocationIndex={currentLocationIndex}
+                onLocationNavigate={handleLocationNavigate}
             />
             <ChatDock />
             <DisasterInfoPanel


### PR DESCRIPTION
## Summary
- **FlyToHandler** component in MapView — smooth `map.flyTo()` animation to any coordinate
- **Dashboard** fetches all florence location centroids on mount, groups by `image_pair_id` into browsable tiles
- **Sidebar** shows a new "Locations (N tiles)" section with prev/next buttons and a scrollable tile list
- Clicking any tile flies the map to its centroid at zoom 17; existing viewport fetch then loads polygons + image overlays for that area
- Also fixes pre-existing TypeScript build errors in chat components (`SubmitEventHandler` → `FormEventHandler`, `RefObject` compat)

## Files changed
- `src/components/map/MapView.tsx` — added `FlyToHandler`, `flyTarget` prop
- `src/pages/Dashboard.tsx` — added wide-bbox fetch, grouping, `flyTarget` state, `handleLocationNavigate`
- `src/components/dashboard/DashboardSidebar.tsx` — added location nav UI (prev/next + tile list)
- `src/components/chat/ChatPanel.tsx` — TS type fix
- `src/components/chat/components/ChatInput.tsx` — TS type fix
- `src/components/chat/components/ChatMessageList.tsx` — TS type fix

## Test plan
- [x] Open sidebar → "Locations" section shows tile count and scrollable list
- [x] Click any tile → map flies smoothly to that location
- [x] Prev/next buttons navigate through tiles, disabled at boundaries
- [x] After flying, polygons and image overlays load for the new viewport
- [x] Production build passes (`npm run build`)
- [x] Full E2E verified: PostGIS + backend + frontend with real florence data

Closes #24, Closes #30