### PR TITLE
fix: resolve TypeScript build errors in chat components

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { SubmitEventHandler } from 'react';
+import type { FormEventHandler } from 'react';
 
 import { createChatHistoryClient } from './clients/history/createChatHistoryClient';
 import { createMockChatHistoryClient } from './clients/history/mockChatHistoryClient';
@@ -281,7 +281,7 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
         };
     }, []);
 
-    const handleSend: SubmitEventHandler<HTMLFormElement> = (event) => {
+    const handleSend: FormEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
 
         const trimmed = draft.trim();

--- a/src/components/chat/components/ChatInput.tsx
+++ b/src/components/chat/components/ChatInput.tsx
@@ -1,11 +1,11 @@
 import { useLayoutEffect, useRef } from 'react';
-import type { SubmitEventHandler } from 'react';
+import type { FormEventHandler } from 'react';
 import { Send } from 'lucide-react';
 
 interface ChatInputProps {
     draft: string;
     onDraftChange: (value: string) => void;
-    onSend: SubmitEventHandler<HTMLFormElement>;
+    onSend: FormEventHandler<HTMLFormElement>;
 }
 
 const ChatInput = ({ draft, onDraftChange, onSend }: ChatInputProps) => {

--- a/src/components/chat/components/ChatMessageList.tsx
+++ b/src/components/chat/components/ChatMessageList.tsx
@@ -1,17 +1,17 @@
-import type { RefObject } from 'react';
+import React from 'react';
 
 import type { ChatMessage } from '../types';
 import ChatBubble from './ChatBubble';
 
 interface ChatMessageListProps {
     messages: ChatMessage[];
-    listRef: RefObject<HTMLDivElement | null>;
+    listRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const ChatMessageList = ({ messages, listRef }: ChatMessageListProps) => {
     return (
         <div
-            ref={listRef}
+            ref={listRef as React.LegacyRef<HTMLDivElement>}
             className="flex h-[360px] flex-col gap-3 overflow-y-auto px-4 py-4"
         >
             {messages.map((message) => (


### PR DESCRIPTION
## Summary
Fixes 3 pre-existing TypeScript errors that prevented `npm run build` from succeeding.

## Changes
- `ChatPanel.tsx`: `SubmitEventHandler` → `FormEventHandler` (React removed the former)
- `ChatInput.tsx`: same fix
- `ChatMessageList.tsx`: `RefObject<HTMLDivElement | null>` → cast for React 18 `LegacyRef` compat

## Test plan
- [x] `npm run build` passes
- [x] Chat UI works (send messages, history, mock conversations)