### PR TITLE
feat: agentic chat — map nav, overlay/filter control, thinking indicator

### DIFF
--- a/src/components/chat/ChatDock.tsx
+++ b/src/components/chat/ChatDock.tsx
@@ -1,14 +1,31 @@
 import { MessageCircle } from 'lucide-react';
 import { useState } from 'react';
 
+import type { ViewportBBox } from '@components/map/MapView';
+
 import ChatPanel from './ChatPanel';
 
-const ChatDock = () => {
+export interface ChatAction {
+    type: "flyTo" | "setOpacity" | "setOverlayMode" | "setFilters";
+    lat?: number;
+    lng?: number;
+    zoom?: number;
+    value?: number;
+    mode?: "pre" | "post" | "none";
+    [key: string]: unknown;
+}
+
+interface ChatDockProps {
+    viewport: ViewportBBox | null;
+    onAction?: (action: ChatAction) => void;
+}
+
+const ChatDock = ({ viewport, onAction }: ChatDockProps) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);
 
     return (
         <div className="absolute bottom-4 right-4 z-[1000] flex flex-col items-end gap-4">
-            {isOpen && <ChatPanel setIsOpen={setIsOpen} />}
+            {isOpen && <ChatPanel setIsOpen={setIsOpen} viewport={viewport} onAction={onAction} />}
             <button
                 className="grid h-14 w-14 place-items-center rounded-xl
                            bg-slate-950 text-white shadow-md

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { SubmitEventHandler } from 'react';
 
+import type { ViewportBBox } from '@components/map/MapView';
+
+import type { ChatAction } from './ChatDock';
 import { createChatHistoryClient } from './clients/history/createChatHistoryClient';
 import { createMockChatHistoryClient } from './clients/history/mockChatHistoryClient';
 import type { ChatHistoryClient } from './clients/history/types';
@@ -29,6 +32,8 @@ import type {
 
 interface ChatPanelProps {
     setIsOpen: (isOpen: boolean) => void;
+    viewport: ViewportBBox | null;
+    onAction?: (action: ChatAction) => void;
 }
 
 const runtimeConfig = getChatRuntimeConfig();
@@ -122,7 +127,7 @@ const hydrateConversations = async (
     );
 };
 
-const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
+const ChatPanel = ({ setIsOpen, viewport, onAction }: ChatPanelProps) => {
     const [conversations, setConversations] =
         useState<ChatConversation[]>(initialConversations);
     const [activeConversationId, setActiveConversationId] =
@@ -131,9 +136,13 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
     const [isHistoryOpen, setIsHistoryOpen] = useState(false);
     const [connectionState, setConnectionState] =
         useState<ChatConnectionState>('connecting');
+    const [isThinking, setIsThinking] = useState(false);
 
     const listRef = useRef<HTMLDivElement | null>(null);
     const realtimeClientRef = useRef<ChatRealtimeClient | null>(null);
+    const backendConversationIdRef = useRef<number | null>(null);
+    const suppressMockRef = useRef(false);
+    const inflightCountRef = useRef(0);
 
     const sortedConversations = useMemo(
         () => sortConversationsByUpdatedAt(conversations),
@@ -168,7 +177,7 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
         }
 
         listRef.current.scrollTop = listRef.current.scrollHeight;
-    }, [activeConversation?.messages]);
+    }, [activeConversation?.messages, isThinking]);
 
     useEffect(() => {
         let isCancelled = false;
@@ -244,6 +253,11 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
                 return;
             }
 
+            // Skip mock response when backend already replied
+            if (suppressMockRef.current) {
+                return;
+            }
+
             const inboundMessage = mapMessageRecordToUiMessage(event.message);
             setConversations((current) =>
                 appendMessageToConversation(
@@ -296,8 +310,11 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
             sentAt: new Date().toISOString(),
         };
 
+        let targetConversationId = effectiveActiveId;
+
         if (effectiveActiveId === NEW_CHAT_ID) {
             const newConversation = createNewConversation(userMessage);
+            targetConversationId = newConversation.id;
             setConversations((current) =>
                 sortConversationsByUpdatedAt([newConversation, ...current]),
             );
@@ -327,6 +344,64 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
         }
 
         setDraft('');
+
+        const { apiBaseUrl } = getChatRuntimeConfig();
+        if (apiBaseUrl) {
+            // Suppress mock while any backend request is in-flight
+            inflightCountRef.current += 1;
+            suppressMockRef.current = true;
+            setIsThinking(true);
+
+            const body: Record<string, unknown> = {
+                message: trimmed,
+                conversation_id: backendConversationIdRef.current,
+            };
+            if (viewport) {
+                body.viewport = viewport;
+            }
+            fetch(`${apiBaseUrl}/chat/message`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            })
+                .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+                .then((data: { conversation_id: number; reply: string; actions?: ChatAction[] }) => {
+                    backendConversationIdRef.current = data.conversation_id;
+                    const agentMessage: ChatMessage = {
+                        id: createMessageId('agent'),
+                        sender: 'agent',
+                        text: data.reply,
+                        sentAt: new Date().toISOString(),
+                    };
+                    setConversations((current) =>
+                        appendMessageToConversation(
+                            current,
+                            targetConversationId,
+                            agentMessage,
+                        ),
+                    );
+                    if (data.actions && Array.isArray(data.actions)) {
+                        for (const action of data.actions) {
+                            onAction?.(action);
+                        }
+                    }
+                })
+                .catch(() => {
+                    // Backend unavailable — allow mock client to respond as fallback
+                })
+                .finally(() => {
+                    inflightCountRef.current -= 1;
+                    if (inflightCountRef.current <= 0) {
+                        inflightCountRef.current = 0;
+                        setIsThinking(false);
+                        suppressMockRef.current = false;
+                    }
+                });
+        } else {
+            // No backend configured — allow mock to respond as fallback
+            suppressMockRef.current = false;
+            setIsThinking(false);
+        }
     };
 
     const handleSelectConversation = (conversationId: string) => {
@@ -361,6 +436,7 @@ const ChatPanel = ({ setIsOpen }: ChatPanelProps) => {
             <ChatMessageList
                 messages={activeConversation?.messages ?? []}
                 listRef={listRef}
+                isThinking={isThinking}
             />
             <ChatInput
                 draft={draft}

--- a/src/components/chat/components/ChatMessageList.tsx
+++ b/src/components/chat/components/ChatMessageList.tsx
@@ -6,9 +6,18 @@ import ChatBubble from './ChatBubble';
 interface ChatMessageListProps {
     messages: ChatMessage[];
     listRef: RefObject<HTMLDivElement | null>;
+    isThinking?: boolean;
 }
 
-const ChatMessageList = ({ messages, listRef }: ChatMessageListProps) => {
+const ThinkingBubble = () => (
+    <div className="flex justify-start">
+        <div className="max-w-[90%] rounded-2xl rounded-bl-md border border-slate-200 bg-white px-3 py-2 shadow-sm">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-slate-600" />
+        </div>
+    </div>
+);
+
+const ChatMessageList = ({ messages, listRef, isThinking = false }: ChatMessageListProps) => {
     return (
         <div
             ref={listRef}
@@ -17,6 +26,7 @@ const ChatMessageList = ({ messages, listRef }: ChatMessageListProps) => {
             {messages.map((message) => (
                 <ChatBubble key={message.id} message={message} />
             ))}
+            {isThinking && <ThinkingBubble />}
         </div>
     );
 };

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -296,12 +296,42 @@ const PolygonWithStyle = ({ polygon }: { polygon: MapPolygon }) => {
     );
 };
 
+export interface FlyTarget {
+    lat: number;
+    lng: number;
+    zoom?: number;
+}
+
+const FlyToHandler = ({ target }: { target: FlyTarget | null }) => {
+    const map = useMap();
+    const lastTargetRef = useRef<FlyTarget | null>(null);
+
+    useEffect(() => {
+        if (
+            !target ||
+            (lastTargetRef.current &&
+                lastTargetRef.current.lat === target.lat &&
+                lastTargetRef.current.lng === target.lng &&
+                lastTargetRef.current.zoom === target.zoom)
+        ) {
+            return;
+        }
+        lastTargetRef.current = target;
+        map.flyTo([target.lat, target.lng], target.zoom ?? 17, {
+            duration: 1.5,
+        });
+    }, [target, map]);
+
+    return null;
+};
+
 interface MapViewProps {
     imageOverlayOpacity?: number;
     imageOverlayMode?: ImageOverlayMode;
     polygons?: MapPolygon[];
     onViewportChange?: (bbox: ViewportBBox) => void;
     disablePolygons?: boolean;
+    flyTarget?: FlyTarget | null;
 }
 
 const MapView = ({
@@ -310,6 +340,7 @@ const MapView = ({
     polygons = [],
     onViewportChange,
     disablePolygons = false,
+    flyTarget = null,
 }: MapViewProps) => {
     const polygonsToRender = disablePolygons ? [] : polygons;
     const [bbox, setBbox] = useState<ViewportBBox | null>(null);
@@ -420,6 +451,7 @@ const MapView = ({
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
             <ViewportWatcher onViewportChange={handleViewportChange} />
+            <FlyToHandler target={flyTarget} />
             {visibleOverlays.map((overlay) => (
                 <ImageOverlay
                     key={`${overlay.id}-${overlay.url}`}

--- a/src/index.css
+++ b/src/index.css
@@ -28,3 +28,4 @@
   height: 100%;
   z-index: 0;
 }
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import ChatDock from "@components/chat/ChatDock";
+import ChatDock, { type ChatAction } from "@components/chat/ChatDock";
 import { getChatRuntimeConfig } from "@components/chat/config";
 import ControlPanel, {
     type ImageOverlayMode,
@@ -9,7 +9,7 @@ import ControlPanel, {
 import DashboardSidebar from "@components/dashboard/DashboardSidebar";
 import DisasterInfoPanel from "@components/dashboard/DisasterInfoPanel";
 import ErrorBoundary from "@components/ErrorBoundary";
-import MapView, { type ViewportBBox } from "@components/map/MapView";
+import MapView, { type FlyTarget, type ViewportBBox } from "@components/map/MapView";
 import { normalizeClassification, type MapPolygon } from "@components/map/types";
 
 const API_BASE_FALLBACK = "http://127.0.0.1:8000";
@@ -135,6 +135,37 @@ const Dashboard = () => {
     );
     const [polygons, setPolygons] = useState<MapPolygon[]>([]);
     const [viewport, setViewport] = useState<ViewportBBox | null>(null);
+    const [flyTarget, setFlyTarget] = useState<FlyTarget | null>(null);
+
+    const VALID_OVERLAY_MODES: ReadonlySet<ImageOverlayMode> = new Set(["pre", "post", "none"]);
+
+    const handleChatAction = useCallback((action: ChatAction) => {
+        if (action.type === "flyTo" && action.lat != null && action.lng != null) {
+            setFlyTarget({ lat: action.lat, lng: action.lng, zoom: action.zoom });
+        } else if (action.type === "setOpacity" && typeof action.value === "number") {
+            const clamped = Math.max(0, Math.min(1, action.value));
+            setImageOverlayOpacity(clamped);
+        } else if (action.type === "setOverlayMode" && VALID_OVERLAY_MODES.has(action.mode as ImageOverlayMode)) {
+            setImageOverlayMode(action.mode as ImageOverlayMode);
+        } else if (action.type === "setFilters") {
+            const boolOrSkip = (v: unknown): boolean | null =>
+                typeof v === "boolean" ? v : null;
+            setLocationToggles((previous) => {
+                const next = { ...previous };
+                const d = boolOrSkip(action.destroyed);
+                const s = boolOrSkip(action.severe);
+                const m = boolOrSkip(action.minor);
+                const n = boolOrSkip(action.none);
+                const u = boolOrSkip(action.unknown);
+                if (d != null) next.destroyed = d;
+                if (s != null) next.severe = s;
+                if (m != null) next.minor = m;
+                if (n != null) next.none = n;
+                if (u != null) next.unknown = u;
+                return next;
+            });
+        }
+    }, []);
 
     useEffect(() => {
         if (!viewport) return;
@@ -186,6 +217,7 @@ const Dashboard = () => {
                         polygons={visiblePolygons}
                         onViewportChange={setViewport}
                         disablePolygons={disableAllArtifacts}
+                        flyTarget={flyTarget}
                     />
                 </ErrorBoundary>
             </div>
@@ -216,7 +248,7 @@ const Dashboard = () => {
                 }}
                 polygons={polygons}
             />
-            <ChatDock />
+            <ChatDock viewport={viewport} onAction={handleChatAction} />
             <DisasterInfoPanel
                 isOpen={isDisasterInfoOpen}
                 onClose={() => setIsDisasterInfoOpen(false)}


### PR DESCRIPTION
## Summary
Adds agentic capabilities to the chat — Gemini can now control the map interface directly based on user requests.

**What the chat can do now:**
- Navigate the map ("take me to the destroyed buildings") 
- Switch satellite overlay mode ("show pre-disaster image")
- Adjust overlay transparency ("make overlay 50% transparent")
- Filter damage classifications ("only show destroyed buildings")
- Reject off-topic queries ("write me a poem" → scoped refusal)

## Changes
- `MapView.tsx` — `FlyToHandler` component + `flyTarget` prop
- `Dashboard.tsx` — `handleChatAction` dispatching 4 action types to existing state setters
- `ChatDock.tsx` — `ChatAction` typed interface, `viewport` + `onAction` prop threading
- `ChatPanel.tsx` — backend POST with viewport context, action dispatch, thinking spinner, mock suppression when backend responds
- `ChatMessageList.tsx` — `ThinkingBubble` with Tailwind `animate-spin` spinner

## Works with
UTDisaster/backend feat/agentic-chat branch (PR pending)

## Test plan
- [x] "Take me to destroyed buildings" → map flies to location
- [x] "Show pre-disaster" → overlay switches
- [x] "Make overlay 30% transparent" → opacity changes
- [x] "Only show destroyed" → filter applied
- [x] "What's a good pasta recipe" → rejected
- [x] Thinking spinner shows while waiting, disappears on response
- [x] No duplicate mock + real responses
- [x] TypeScript build passes