### PR TITLE
feat: add backend status pill to the dashboard (#50)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
-import Dashboard from './pages/Dashboard';
+import { BackendStatusProvider } from "./contexts/BackendStatusContext";
+import Dashboard from "./pages/Dashboard";
+
+const API_BASE_URL =
+    (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(
+        /\/$/,
+        "",
+    ) || "http://127.0.0.1:8000";
 
 function App() {
-    return <Dashboard />;
+    return (
+        <BackendStatusProvider apiBase={API_BASE_URL}>
+            <Dashboard />
+        </BackendStatusProvider>
+    );
 }
 
 export default App;

--- a/src/components/controls/ControlPanel.tsx
+++ b/src/components/controls/ControlPanel.tsx
@@ -26,6 +26,7 @@ interface ControlPanelProps {
     ) => void;
     onMenuClick?: () => void;
     isSidebarOpen?: boolean;
+    onOverlayMenuOpenChange?: (open: boolean) => void;
 }
 
 const imageOptions: { label: string; value: ImageOverlayMode }[] = [
@@ -57,9 +58,14 @@ const ControlPanel = ({
     onLocationToggleChange,
     onMenuClick,
     isSidebarOpen,
+    onOverlayMenuOpenChange,
 }: ControlPanelProps) => {
     const [isOverlayMenuOpen, setIsOverlayMenuOpen] = useState(false);
     const overlayMenuRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        onOverlayMenuOpenChange?.(isOverlayMenuOpen);
+    }, [isOverlayMenuOpen, onOverlayMenuOpenChange]);
 
     useEffect(() => {
         if (!isOverlayMenuOpen) return;
@@ -104,173 +110,181 @@ const ControlPanel = ({
                     <Menu className="h-6 w-6 text-slate-900" />
                 </button>
             )}
-            {!isSidebarOpen && <div
-                ref={overlayMenuRef}
-                className="relative flex items-center gap-2
+            {!isSidebarOpen && (
+                <div
+                    ref={overlayMenuRef}
+                    className="relative flex items-center gap-2
                                         p-2
                                         rounded-xl
                                         border border-white/80 bg-white/90
                                         shadow-md backdrop-blur-md
                                         pointer-events-auto"
-            >
-                <button
-                    type="button"
-                    className="flex items-center gap-2
+                >
+                    <button
+                        type="button"
+                        className="flex items-center gap-2
                                px-4 py-2
                                text-sm font-semibold text-slate-900
                                rounded-lg
                                transition hover:bg-white/90 hover:text-blue-600"
-                    onClick={() => setIsOverlayMenuOpen((open) => !open)}
-                    aria-expanded={isOverlayMenuOpen}
-                    aria-haspopup="true"
-                    aria-controls="overlays-popup-menu"
-                >
-                    <Layers className="h-4 w-4" />
-                    Overlays
-                </button>
+                        onClick={() => setIsOverlayMenuOpen((open) => !open)}
+                        aria-expanded={isOverlayMenuOpen}
+                        aria-haspopup="true"
+                        aria-controls="overlays-popup-menu"
+                    >
+                        <Layers className="h-4 w-4" />
+                        Overlays
+                    </button>
 
-                {isOverlayMenuOpen ? (
-                    <div
-                        id="overlays-popup-menu"
-                        className="absolute right-0 top-full mt-2 w-80
+                    {isOverlayMenuOpen ? (
+                        <div
+                            id="overlays-popup-menu"
+                            className="absolute right-0 top-full mt-2 w-80
                                    rounded-xl border border-slate-200 bg-white p-3
                                    shadow-xl"
-                    >
-                        <section className="mb-3 border-b border-slate-200 pb-3">
-                            <h3 className="mb-2 text-xs font-bold uppercase tracking-wide text-slate-500">
-                                Images
-                            </h3>
-                            <div className="flex gap-2">
-                                {imageOptions.map((option) => {
-                                    const isActive =
-                                        option.value === imageOverlayMode;
-                                    return (
-                                        <button
-                                            key={option.value}
-                                            type="button"
-                                            className={`rounded-md border px-3 py-1.5 text-sm font-semibold transition ${
-                                                isActive
-                                                    ? "border-blue-600 bg-blue-600 text-white"
-                                                    : "border-slate-300 text-slate-700 hover:bg-slate-100"
-                                            }`}
-                                            onClick={() =>
-                                                onImageOverlayModeChange(
-                                                    option.value,
-                                                )
-                                            }
-                                        >
-                                            {option.label}
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                            <div className="mt-3">
-                                <div className="mb-1 flex items-center justify-between">
-                                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                                        Opacity
-                                    </span>
-                                    <span className="text-xs font-semibold text-slate-600">
-                                        {Math.round(imageOverlayOpacity * 100)}%
-                                    </span>
-                                </div>
-                                <input
-                                    type="range"
-                                    min={0}
-                                    max={100}
-                                    step={1}
-                                    value={Math.round(
-                                        imageOverlayOpacity * 100,
-                                    )}
-                                    onChange={(event) =>
-                                        onImageOverlayOpacityChange(
-                                            Number(event.target.value) / 100,
-                                        )
-                                    }
-                                    className="w-full accent-blue-600"
-                                    aria-label="Image overlay opacity"
-                                />
-                            </div>
-                        </section>
-
-                        <section>
-                            <div className="mb-2 flex items-center justify-between">
-                                <h3 className="text-xs font-bold uppercase tracking-wide text-slate-500">
-                                    Artifacts
+                        >
+                            <section className="mb-3 border-b border-slate-200 pb-3">
+                                <h3 className="mb-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                                    Images
                                 </h3>
-                                <button
-                                    type="button"
-                                    role="switch"
-                                    aria-checked={!disableAllArtifacts}
-                                    aria-label="Toggle artifacts"
-                                    className={`relative h-5 w-9 rounded-full transition ${
-                                        disableAllArtifacts
-                                            ? "bg-slate-300"
-                                            : "bg-blue-600"
-                                    }`}
-                                    onClick={() =>
-                                        onDisableAllArtifactsChange(
-                                            !disableAllArtifacts,
-                                        )
-                                    }
-                                >
-                                    <span
-                                        className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition ${
-                                            disableAllArtifacts
-                                                ? "left-0.5"
-                                                : "left-[18px]"
-                                        }`}
-                                    />
-                                </button>
-                            </div>
-
-                            {!disableAllArtifacts ? (
-                                <div className="rounded-md border border-slate-200 p-2">
-                                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                                        Locations
-                                    </h4>
-                                    <div className="flex flex-wrap gap-2">
-                                        {locationOptions.map((option) => (
+                                <div className="flex gap-2">
+                                    {imageOptions.map((option) => {
+                                        const isActive =
+                                            option.value === imageOverlayMode;
+                                        return (
                                             <button
-                                                key={option.key}
+                                                key={option.value}
                                                 type="button"
-                                                className={`group relative h-7 w-7 rounded-full border-2 transition ${
-                                                    locationToggles[option.key]
-                                                        ? `${option.colorClass} border-white ring-2 ring-slate-300`
-                                                        : `${option.colorClass} border-slate-300 saturate-50 brightness-110`
+                                                className={`rounded-md border px-3 py-1.5 text-sm font-semibold transition ${
+                                                    isActive
+                                                        ? "border-blue-600 bg-blue-600 text-white"
+                                                        : "border-slate-300 text-slate-700 hover:bg-slate-100"
                                                 }`}
                                                 onClick={() =>
-                                                    onLocationToggleChange(
-                                                        option.key,
-                                                        !locationToggles[
-                                                            option.key
-                                                        ],
+                                                    onImageOverlayModeChange(
+                                                        option.value,
                                                     )
                                                 }
-                                                aria-label={option.label}
                                             >
-                                                <span
-                                                    className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs font-semibold text-white opacity-0 transition group-hover:opacity-100"
-                                                    aria-hidden
-                                                >
-                                                    {option.label}
-                                                </span>
-                                                {!locationToggles[
-                                                    option.key
-                                                ] ? (
-                                                    <span
-                                                        className="pointer-events-none absolute left-1/2 top-1/2 h-0.5 w-6 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded bg-slate-700"
-                                                        aria-hidden
-                                                    />
-                                                ) : null}
+                                                {option.label}
                                             </button>
-                                        ))}
-                                    </div>
+                                        );
+                                    })}
                                 </div>
-                            ) : null}
-                        </section>
-                    </div>
-                ) : null}
-            </div>}
+                                <div className="mt-3">
+                                    <div className="mb-1 flex items-center justify-between">
+                                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                            Opacity
+                                        </span>
+                                        <span className="text-xs font-semibold text-slate-600">
+                                            {Math.round(
+                                                imageOverlayOpacity * 100,
+                                            )}
+                                            %
+                                        </span>
+                                    </div>
+                                    <input
+                                        type="range"
+                                        min={0}
+                                        max={100}
+                                        step={1}
+                                        value={Math.round(
+                                            imageOverlayOpacity * 100,
+                                        )}
+                                        onChange={(event) =>
+                                            onImageOverlayOpacityChange(
+                                                Number(event.target.value) /
+                                                    100,
+                                            )
+                                        }
+                                        className="w-full accent-blue-600"
+                                        aria-label="Image overlay opacity"
+                                    />
+                                </div>
+                            </section>
+
+                            <section>
+                                <div className="mb-2 flex items-center justify-between">
+                                    <h3 className="text-xs font-bold uppercase tracking-wide text-slate-500">
+                                        Artifacts
+                                    </h3>
+                                    <button
+                                        type="button"
+                                        role="switch"
+                                        aria-checked={!disableAllArtifacts}
+                                        aria-label="Toggle artifacts"
+                                        className={`relative h-5 w-9 rounded-full transition ${
+                                            disableAllArtifacts
+                                                ? "bg-slate-300"
+                                                : "bg-blue-600"
+                                        }`}
+                                        onClick={() =>
+                                            onDisableAllArtifactsChange(
+                                                !disableAllArtifacts,
+                                            )
+                                        }
+                                    >
+                                        <span
+                                            className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition ${
+                                                disableAllArtifacts
+                                                    ? "left-0.5"
+                                                    : "left-[18px]"
+                                            }`}
+                                        />
+                                    </button>
+                                </div>
+
+                                {!disableAllArtifacts ? (
+                                    <div className="rounded-md border border-slate-200 p-2">
+                                        <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                            Locations
+                                        </h4>
+                                        <div className="flex flex-wrap gap-2">
+                                            {locationOptions.map((option) => (
+                                                <button
+                                                    key={option.key}
+                                                    type="button"
+                                                    className={`group relative h-7 w-7 rounded-full border-2 transition ${
+                                                        locationToggles[
+                                                            option.key
+                                                        ]
+                                                            ? `${option.colorClass} border-white ring-2 ring-slate-300`
+                                                            : `${option.colorClass} border-slate-300 saturate-50 brightness-110`
+                                                    }`}
+                                                    onClick={() =>
+                                                        onLocationToggleChange(
+                                                            option.key,
+                                                            !locationToggles[
+                                                                option.key
+                                                            ],
+                                                        )
+                                                    }
+                                                    aria-label={option.label}
+                                                >
+                                                    <span
+                                                        className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs font-semibold text-white opacity-0 transition group-hover:opacity-100"
+                                                        aria-hidden
+                                                    >
+                                                        {option.label}
+                                                    </span>
+                                                    {!locationToggles[
+                                                        option.key
+                                                    ] ? (
+                                                        <span
+                                                            className="pointer-events-none absolute left-1/2 top-1/2 h-0.5 w-6 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded bg-slate-700"
+                                                            aria-hidden
+                                                        />
+                                                    ) : null}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </div>
+                                ) : null}
+                            </section>
+                        </div>
+                    ) : null}
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -1,4 +1,10 @@
-import { ChevronDown, ChevronLeft, ChevronRight, Info, MapPin } from "lucide-react";
+import {
+    ChevronDown,
+    ChevronLeft,
+    ChevronRight,
+    Info,
+    MapPin,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -114,9 +120,11 @@ const DashboardSidebar = ({
                            shadow-xl backdrop-blur-md"
             >
                 <div className="flex h-14 items-center justify-between border-b border-slate-900/10 px-4">
-                    <p className="font-display text-sm font-bold text-slate-900">
-                        Menu
-                    </p>
+                    <div className="flex items-center gap-2">
+                        <p className="font-display text-sm font-bold text-slate-900">
+                            Menu
+                        </p>
+                    </div>
                     <button
                         type="button"
                         className="grid h-8 w-8 place-items-center rounded-lg
@@ -239,21 +247,33 @@ const DashboardSidebar = ({
                                                text-slate-600 transition hover:bg-slate-100
                                                disabled:opacity-40 disabled:pointer-events-none"
                                     disabled={currentLocationIndex <= 0}
-                                    onClick={() => onLocationNavigate?.(currentLocationIndex - 1)}
+                                    onClick={() =>
+                                        onLocationNavigate?.(
+                                            currentLocationIndex - 1,
+                                        )
+                                    }
                                     aria-label="Previous location"
                                 >
                                     <ChevronLeft className="h-4 w-4" />
                                 </button>
                                 <span className="text-sm font-medium text-slate-700">
-                                    {currentLocationIndex + 1} / {disasterLocations.length}
+                                    {currentLocationIndex + 1} /{" "}
+                                    {disasterLocations.length}
                                 </span>
                                 <button
                                     type="button"
                                     className="grid h-7 w-7 place-items-center rounded-lg
                                                text-slate-600 transition hover:bg-slate-100
                                                disabled:opacity-40 disabled:pointer-events-none"
-                                    disabled={currentLocationIndex >= disasterLocations.length - 1}
-                                    onClick={() => onLocationNavigate?.(currentLocationIndex + 1)}
+                                    disabled={
+                                        currentLocationIndex >=
+                                        disasterLocations.length - 1
+                                    }
+                                    onClick={() =>
+                                        onLocationNavigate?.(
+                                            currentLocationIndex + 1,
+                                        )
+                                    }
                                     aria-label="Next location"
                                 >
                                     <ChevronRight className="h-4 w-4" />
@@ -269,7 +289,9 @@ const DashboardSidebar = ({
                                                     ? "bg-blue-50 font-semibold text-blue-700"
                                                     : "text-slate-700 hover:bg-slate-100"
                                             }`}
-                                            onClick={() => onLocationNavigate?.(i)}
+                                            onClick={() =>
+                                                onLocationNavigate?.(i)
+                                            }
                                         >
                                             Tile {i + 1}
                                             <span className="ml-1 text-xs text-slate-400">

--- a/src/components/dashboard/StatusPill.tsx
+++ b/src/components/dashboard/StatusPill.tsx
@@ -1,0 +1,62 @@
+import type { BackendStatus } from "../../contexts/BackendStatusContext";
+
+interface StatusPillProps {
+    status: BackendStatus;
+    lastError: string | null;
+    lastSeen: number | null;
+}
+
+const DOT_CLASSES: Record<BackendStatus, string> = {
+    up: "bg-green-500",
+    degraded: "bg-yellow-400",
+    down: "bg-red-500",
+};
+
+const LABELS: Record<BackendStatus, string> = {
+    up: "Live",
+    degraded: "Data issues",
+    down: "Offline",
+};
+
+const humanizeLastSeen = (lastSeen: number | null): string => {
+    if (lastSeen == null) return "never";
+    const deltaMs = Date.now() - lastSeen;
+    const seconds = Math.max(0, Math.floor(deltaMs / 1000));
+    if (seconds < 5) return "just now";
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ago`;
+};
+
+const buildTitle = (
+    status: BackendStatus,
+    lastError: string | null,
+    lastSeen: number | null,
+): string => {
+    const parts: string[] = [`Backend: ${LABELS[status]}`];
+    parts.push(`Last seen: ${humanizeLastSeen(lastSeen)}`);
+    if (lastError) parts.push(`Last error: ${lastError}`);
+    return parts.join(" \u2014 ");
+};
+
+const StatusPill = ({ status, lastError, lastSeen }: StatusPillProps) => {
+    return (
+        <span
+            className="inline-flex items-center gap-1.5 rounded-full
+                       border border-slate-300 bg-slate-100 px-2 py-0.5
+                       text-xs font-medium text-slate-700"
+            title={buildTitle(status, lastError, lastSeen)}
+            aria-label={`Backend status: ${LABELS[status]}`}
+        >
+            <span
+                className={`h-2 w-2 rounded-full ${DOT_CLASSES[status]}`}
+                aria-hidden
+            />
+            {LABELS[status]}
+        </span>
+    );
+};
+
+export default StatusPill;

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-leaflet";
 
 import type { ImageOverlayMode } from "@components/controls/ControlPanel";
+import { useBackendStatusContext } from "../../contexts/BackendStatusContext";
 import { normalizeClassification, type MapPolygon } from "./types";
 
 const DEFAULT_CENTER: [number, number] = [33.6036, -79.0346];
@@ -387,6 +388,8 @@ const MapView = ({
     const [isLoadingTiles, setIsLoadingTiles] = useState(false);
     const requestAbortRef = useRef<AbortController | null>(null);
     const bboxRef = useRef<ViewportBBox | null>(null);
+    const { reportFetchSuccess, reportFetchFailure } =
+        useBackendStatusContext();
 
     const handleViewportChange = useCallback(
         (nextBbox: ViewportBBox) => {
@@ -419,6 +422,7 @@ const MapView = ({
                 }
 
                 const payload = (await response.json()) as ApiImagePairResponse;
+                reportFetchSuccess();
                 const overlays: RenderableImagePair[] = (
                     payload.image_pairs ?? []
                 )
@@ -443,7 +447,9 @@ const MapView = ({
                 setImagePairs(overlays);
             } catch (error) {
                 if (controller.signal.aborted) return;
-                console.error("Failed to fetch image pairs:", error);
+                const msg =
+                    error instanceof Error ? error.message : String(error);
+                reportFetchFailure(msg);
                 setImagePairs([]);
             } finally {
                 if (!controller.signal.aborted) {
@@ -457,7 +463,7 @@ const MapView = ({
         return () => {
             controller.abort();
         };
-    }, [bbox]);
+    }, [bbox, reportFetchSuccess, reportFetchFailure]);
 
     const visibleOverlays = useMemo(() => {
         if (imageOverlayMode === "none") {

--- a/src/contexts/BackendStatusContext.tsx
+++ b/src/contexts/BackendStatusContext.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+    type ReactNode,
+} from "react";
+
+export type PolledStatus = "up" | "down" | "unknown";
+export type BackendStatus = "up" | "degraded" | "down";
+
+const POLL_INTERVAL_MS = 15000;
+const FETCH_TIMEOUT_MS = 3000;
+
+export interface BackendStatusContextValue {
+    polled: PolledStatus;
+    lastFetchOk: boolean;
+    lastFetchError: string | null;
+    lastSeen: number | null;
+    reportFetchSuccess: () => void;
+    reportFetchFailure: (msg: string) => void;
+}
+
+export interface UseBackendStatusResult {
+    status: BackendStatus;
+    lastError: string | null;
+    lastSeen: number | null;
+}
+
+const BackendStatusContext = createContext<BackendStatusContextValue | null>(
+    null,
+);
+
+interface BackendStatusProviderProps {
+    apiBase: string;
+    children: ReactNode;
+}
+
+export const BackendStatusProvider = ({
+    apiBase,
+    children,
+}: BackendStatusProviderProps) => {
+    const [polled, setPolled] = useState<PolledStatus>("unknown");
+    const [lastFetchOk, setLastFetchOk] = useState<boolean>(true);
+    const [lastFetchError, setLastFetchError] = useState<string | null>(null);
+    const [lastSeen, setLastSeen] = useState<number | null>(null);
+
+    const reportFetchSuccess = useCallback(() => {
+        setLastFetchOk(true);
+        setLastFetchError(null);
+    }, []);
+
+    const reportFetchFailure = useCallback((msg: string) => {
+        setLastFetchOk(false);
+        setLastFetchError(msg);
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        const base = apiBase.replace(/\/+$/, "");
+        // Track in-flight controller and timer so cleanup can abort them.
+        let activeController: AbortController | null = null;
+        let activeTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const ping = async () => {
+            const controller = new AbortController();
+            activeController = controller;
+            activeTimer = setTimeout(
+                () => controller.abort(),
+                FETCH_TIMEOUT_MS,
+            );
+            try {
+                const res = await fetch(`${base}/health`, {
+                    signal: controller.signal,
+                });
+                if (cancelled) return;
+                if (res.ok) {
+                    setPolled("up");
+                    setLastSeen(Date.now());
+                } else {
+                    setPolled("down");
+                }
+            } catch {
+                if (cancelled) return;
+                setPolled("down");
+            } finally {
+                if (activeTimer) clearTimeout(activeTimer);
+                if (activeController === controller) {
+                    activeController = null;
+                    activeTimer = null;
+                }
+            }
+        };
+
+        void ping();
+        const interval = setInterval(ping, POLL_INTERVAL_MS);
+
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+            if (activeTimer) clearTimeout(activeTimer);
+            if (activeController) activeController.abort();
+        };
+    }, [apiBase]);
+
+    const value = useMemo<BackendStatusContextValue>(
+        () => ({
+            polled,
+            lastFetchOk,
+            lastFetchError,
+            lastSeen,
+            reportFetchSuccess,
+            reportFetchFailure,
+        }),
+        [
+            polled,
+            lastFetchOk,
+            lastFetchError,
+            lastSeen,
+            reportFetchSuccess,
+            reportFetchFailure,
+        ],
+    );
+
+    return (
+        <BackendStatusContext.Provider value={value}>
+            {children}
+        </BackendStatusContext.Provider>
+    );
+};
+
+export const useBackendStatusContext = (): BackendStatusContextValue => {
+    const ctx = useContext(BackendStatusContext);
+    if (!ctx) {
+        throw new Error(
+            "useBackendStatusContext must be used within BackendStatusProvider",
+        );
+    }
+    return ctx;
+};
+
+export const useBackendStatus = (): UseBackendStatusResult => {
+    const { polled, lastFetchOk, lastFetchError, lastSeen } =
+        useBackendStatusContext();
+
+    let status: BackendStatus;
+    if (polled === "down") {
+        status = "down";
+    } else if (polled === "up" && !lastFetchOk) {
+        status = "degraded";
+    } else {
+        status = "up";
+    }
+
+    return { status, lastError: lastFetchError, lastSeen };
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import ControlPanel, {
 } from "@components/controls/ControlPanel";
 import DashboardSidebar from "@components/dashboard/DashboardSidebar";
 import DisasterInfoPanel from "@components/dashboard/DisasterInfoPanel";
+import StatusPill from "@components/dashboard/StatusPill";
 import ErrorBoundary from "@components/ErrorBoundary";
 import MapView, {
     type FlyTarget,
@@ -19,6 +20,10 @@ import {
     normalizeClassification,
     type MapPolygon,
 } from "@components/map/types";
+import {
+    useBackendStatus,
+    useBackendStatusContext,
+} from "../contexts/BackendStatusContext";
 
 const API_BASE_FALLBACK = "http://127.0.0.1:8000";
 
@@ -142,6 +147,7 @@ function featuresToMapPolygons(features: unknown[]): MapPolygon[] {
 const Dashboard = () => {
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
     const [isDisasterInfoOpen, setIsDisasterInfoOpen] = useState(false);
+    const [isOverlayMenuOpen, setIsOverlayMenuOpen] = useState(false);
     const [imageOverlayMode, setImageOverlayMode] =
         useState<ImageOverlayMode>("post");
     const [imageOverlayOpacity, setImageOverlayOpacity] = useState(0.8);
@@ -172,6 +178,9 @@ const Dashboard = () => {
     const [currentLocationIndex, setCurrentLocationIndex] = useState(0);
     const [viewport, setViewport] = useState<ViewportBBox | null>(null);
     const [flyTarget, setFlyTarget] = useState<FlyTarget | null>(null);
+    const { reportFetchSuccess, reportFetchFailure } =
+        useBackendStatusContext();
+    const backend = useBackendStatus();
 
     const VALID_OVERLAY_MODES: ReadonlySet<ImageOverlayMode> = new Set([
         "pre",
@@ -248,6 +257,7 @@ const Dashboard = () => {
             .then((data: { features?: unknown[] }) => {
                 // Advance the bounds cache only on successful delivery.
                 commitBounds(fetchBounds);
+                reportFetchSuccess();
                 // Merge into cache map keyed by id to deduplicate across fetches.
                 const newPolygons = featuresToMapPolygons(data.features ?? []);
                 for (const p of newPolygons) {
@@ -264,14 +274,22 @@ const Dashboard = () => {
             })
             .catch((error) => {
                 if (controller.signal.aborted) return;
-                console.error("Failed to fetch locations:", error);
+                const msg =
+                    error instanceof Error ? error.message : String(error);
+                reportFetchFailure(msg);
             })
             .finally(() => {
                 if (!controller.signal.aborted) setIsLoadingLocations(false);
             });
 
         return () => controller.abort();
-    }, [viewport, checkBounds, commitBounds]);
+    }, [
+        viewport,
+        checkBounds,
+        commitBounds,
+        reportFetchSuccess,
+        reportFetchFailure,
+    ]);
 
     // Expose a manual invalidation for future filter-reset UX; keeps the
     // reset path in scope so the session cache can be cleared deliberately.
@@ -295,6 +313,7 @@ const Dashboard = () => {
                 r.ok ? r.json() : Promise.reject(new Error(`${r.status}`)),
             )
             .then((data: { features?: ApiLocationFeature[] }) => {
+                reportFetchSuccess();
                 const byPair = new Map<
                     string,
                     { lats: number[]; lngs: number[]; count: number }
@@ -337,11 +356,13 @@ const Dashboard = () => {
             })
             .catch((error) => {
                 if (controller.signal.aborted) return;
-                console.error("Failed to fetch disaster locations:", error);
+                const msg =
+                    error instanceof Error ? error.message : String(error);
+                reportFetchFailure(msg);
             });
 
         return () => controller.abort();
-    }, []);
+    }, [reportFetchSuccess, reportFetchFailure]);
 
     const handleLocationNavigate = useCallback(
         (index: number) => {
@@ -398,7 +419,19 @@ const Dashboard = () => {
                         [key]: enabled,
                     }));
                 }}
+                onOverlayMenuOpenChange={setIsOverlayMenuOpen}
             />
+            <div
+                className={`fixed right-4 z-[1000] transition-[top] duration-200 ${
+                    isOverlayMenuOpen ? "top-[28rem]" : "top-20"
+                }`}
+            >
+                <StatusPill
+                    status={backend.status}
+                    lastError={backend.lastError}
+                    lastSeen={backend.lastSeen}
+                />
+            </div>
             <DashboardSidebar
                 isOpen={isSidebarOpen}
                 onClose={() => setIsSidebarOpen(false)}


### PR DESCRIPTION
Closes #50.

Adds a small colored pill to the map that shows whether the backend is live, having trouble, or completely down. Lets a demo viewer tell "no images in this area" apart from "the server is dead" at a glance.

## What is new
- `BackendStatusProvider` polls `/health` every 15 seconds with a 3 second timeout. Aborts any in-flight request when the page unmounts so fetches do not leak.
- Three pill states:
  - **Live** (green) backend is up and data is loading
  - **Data issues** (yellow) backend is up but a data fetch just failed
  - **Offline** (red) backend is not responding
- Pill sits just below the Overlays button in the top right. When the Overlays dropdown is opened the pill slides down so it stays visible below the open panel.
- `Dashboard` and `MapView` now report fetch successes and failures through the context, which drives the yellow state.

## What is NOT in this PR
- No new npm dependencies.
- No retry or backoff logic on the health poll.
- No test changes. The project has no frontend test harness today.

## Test plan
- [ ] Load the app with the backend running. Pill is green within ~15s.
- [ ] Stop the backend. Pill turns red within ~15s. Tooltip shows the connection error.
- [ ] Start the backend again. Pill returns to green.
- [ ] Open the Overlays dropdown. Pill slides down below the panel and stays visible. Close the dropdown, pill slides back up.
- [ ] Confirm the pill is not inside the sidebar (it should be visible even when the sidebar is collapsed).