### PR TITLE
feat: smart default viewport and full Florence summary (#47, #49)

### DIFF
--- a/src/components/dashboard/DisasterInfoPanel.tsx
+++ b/src/components/dashboard/DisasterInfoPanel.tsx
@@ -74,7 +74,10 @@ const computeStats = (polygons: MapPolygon[]) => {
 
     const hasBounds = Number.isFinite(minLat);
 
-    return { counts, bounds: hasBounds ? { minLat, maxLat, minLng, maxLng } : null };
+    return {
+        counts,
+        bounds: hasBounds ? { minLat, maxLat, minLng, maxLng } : null,
+    };
 };
 
 const DisasterInfoPanel = ({
@@ -217,7 +220,10 @@ const DisasterInfoPanel = ({
                                         ? Math.round((count / total) * 100)
                                         : 0;
                                 return (
-                                    <div key={key} className="flex items-center gap-3">
+                                    <div
+                                        key={key}
+                                        className="flex items-center gap-3"
+                                    >
                                         <span
                                             className={`h-3 w-3 rounded-full ${classificationColors[key]}`}
                                         />

--- a/src/components/dashboard/DisasterInfoPanel.tsx
+++ b/src/components/dashboard/DisasterInfoPanel.tsx
@@ -1,11 +1,20 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 
+import { getChatRuntimeConfig } from "@components/chat/config";
 import {
     normalizeClassification,
     type ClassificationKey,
     type MapPolygon,
 } from "@components/map/types";
+
+const API_BASE_FALLBACK = "http://127.0.0.1:8000";
+const DISASTER_ID = "hurricane-florence";
+
+interface DisasterSummary {
+    description?: string;
+    name?: string;
+}
 
 interface DisasterInfoPanelProps {
     isOpen: boolean;
@@ -74,6 +83,8 @@ const DisasterInfoPanel = ({
     polygons,
 }: DisasterInfoPanelProps) => {
     const dialogRef = useRef<HTMLDivElement>(null);
+    const [summary, setSummary] = useState<DisasterSummary | null>(null);
+    const [summaryFailed, setSummaryFailed] = useState(false);
 
     useEffect(() => {
         if (!isOpen) return;
@@ -86,6 +97,26 @@ const DisasterInfoPanel = ({
         document.addEventListener("keydown", handleKeyDown);
         return () => document.removeEventListener("keydown", handleKeyDown);
     }, [isOpen, onClose]);
+
+    useEffect(() => {
+        const { apiBaseUrl } = getChatRuntimeConfig();
+        const base = (apiBaseUrl || API_BASE_FALLBACK).replace(/\/+$/, "");
+        const controller = new AbortController();
+
+        fetch(`${base}/disasters/${DISASTER_ID}/summary`, {
+            signal: controller.signal,
+        })
+            .then((r) =>
+                r.ok ? r.json() : Promise.reject(new Error(`${r.status}`)),
+            )
+            .then((data: DisasterSummary) => setSummary(data))
+            .catch(() => {
+                if (controller.signal.aborted) return;
+                setSummaryFailed(true);
+            });
+
+        return () => controller.abort();
+    }, []);
 
     if (!isOpen) return null;
 
@@ -131,14 +162,21 @@ const DisasterInfoPanel = ({
                 <div className="space-y-4 px-5 py-4">
                     <section>
                         <h3 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">
-                            Description
+                            {summary?.name ?? "Hurricane Florence"}
                         </h3>
-                        <p className="text-sm leading-relaxed text-slate-700">
-                            Hurricane damage assessment for the Myrtle Beach,
-                            South Carolina region. Satellite imagery and
-                            location data are used to classify structural damage
-                            across the affected area.
-                        </p>
+                        {summary?.description ? (
+                            <p className="text-sm leading-relaxed text-slate-700">
+                                {summary.description}
+                            </p>
+                        ) : summaryFailed ? (
+                            <p className="text-sm leading-relaxed text-slate-500 italic">
+                                Summary unavailable.
+                            </p>
+                        ) : (
+                            <p className="text-sm leading-relaxed text-slate-400">
+                                Loading summary...
+                            </p>
+                        )}
                     </section>
 
                     {bounds && (

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -64,6 +64,7 @@ interface VisibleOverlay {
 
 interface ViewportWatcherProps {
     onViewportChange: (bbox: ViewportBBox) => void;
+    onViewportSettle?: (center: [number, number], zoom: number) => void;
 }
 
 const boundsToBbox = (bounds: LatLngBounds): ViewportBBox => ({
@@ -227,16 +228,31 @@ const clipOverlappingOverlays = (
     return result;
 };
 
-const ViewportWatcher = ({ onViewportChange }: ViewportWatcherProps) => {
+const ViewportWatcher = ({
+    onViewportChange,
+    onViewportSettle,
+}: ViewportWatcherProps) => {
     const map = useMap();
 
     useEffect(() => {
         onViewportChange(boundsToBbox(map.getBounds()));
     }, [map, onViewportChange]);
 
+    const emitSettle = () => {
+        if (!onViewportSettle) return;
+        const c = map.getCenter();
+        onViewportSettle([c.lat, c.lng], map.getZoom());
+    };
+
     useMapEvents({
-        moveend: () => onViewportChange(boundsToBbox(map.getBounds())),
-        zoomend: () => onViewportChange(boundsToBbox(map.getBounds())),
+        moveend: () => {
+            onViewportChange(boundsToBbox(map.getBounds()));
+            emitSettle();
+        },
+        zoomend: () => {
+            onViewportChange(boundsToBbox(map.getBounds()));
+            emitSettle();
+        },
     });
 
     return null;
@@ -370,6 +386,9 @@ interface MapViewProps {
     disablePolygons?: boolean;
     flyTarget?: FlyTarget | null;
     isLoading?: boolean;
+    initialCenter?: [number, number];
+    initialZoom?: number;
+    onViewportSettle?: (center: [number, number], zoom: number) => void;
 }
 
 const MapView = ({
@@ -380,6 +399,9 @@ const MapView = ({
     disablePolygons = false,
     flyTarget = null,
     isLoading = false,
+    initialCenter = DEFAULT_CENTER,
+    initialZoom = DEFAULT_ZOOM,
+    onViewportSettle,
 }: MapViewProps) => {
     const polygonsToRender = disablePolygons ? [] : polygons;
     const [bbox, setBbox] = useState<ViewportBBox | null>(null);
@@ -491,8 +513,8 @@ const MapView = ({
                 <div className="absolute top-0 left-0 right-0 h-1 bg-blue-500 animate-pulse z-[1000]" />
             )}
             <MapContainer
-                center={DEFAULT_CENTER}
-                zoom={DEFAULT_ZOOM}
+                center={initialCenter}
+                zoom={initialZoom}
                 className="h-full w-full"
                 scrollWheelZoom
                 zoomControl={false}
@@ -502,7 +524,10 @@ const MapView = ({
                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
-                <ViewportWatcher onViewportChange={handleViewportChange} />
+                <ViewportWatcher
+                    onViewportChange={handleViewportChange}
+                    onViewportSettle={onViewportSettle}
+                />
                 <FlyToHandler target={flyTarget} />
                 {visibleOverlays.map((overlay) => (
                     <ImageOverlay

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -1,18 +1,19 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 /**
  * Returns a debounced version of the given callback.
  * The returned function delays invocation until `delay` ms have elapsed
  * since the last call.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useDebouncedCallback<A extends any[]>(
+export function useDebouncedCallback<A extends unknown[]>(
     callback: (...args: A) => void,
     delay: number,
 ): (...args: A) => void {
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const callbackRef = useRef(callback);
-    callbackRef.current = callback;
+    useLayoutEffect(() => {
+        callbackRef.current = callback;
+    });
 
     // Clear pending timer on unmount to avoid firing against an unmounted component
     useEffect(() => {

--- a/src/hooks/useInitialViewport.ts
+++ b/src/hooks/useInitialViewport.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+
+import { loadViewport } from "../lib/viewportStorage";
+
+const FALLBACK_CENTER: [number, number] = [33.6036, -79.0346];
+const FALLBACK_ZOOM = 15;
+const HOTSPOT_ZOOM = 16;
+const FETCH_TIMEOUT_MS = 3000;
+
+interface Hotspot {
+    lat?: unknown;
+    lng?: unknown;
+}
+interface HotspotsResponse {
+    hotspots?: Hotspot[];
+}
+export interface InitialViewport {
+    center: [number, number];
+    zoom: number;
+    ready: boolean;
+}
+
+const fallback = (ready: boolean): InitialViewport => ({
+    center: FALLBACK_CENTER,
+    zoom: FALLBACK_ZOOM,
+    ready,
+});
+
+export function useInitialViewport(
+    apiBase: string,
+    disasterId: string,
+): InitialViewport {
+    const [state, setState] = useState<InitialViewport>(() => {
+        const stored = loadViewport();
+        if (stored) {
+            return { center: stored.center, zoom: stored.zoom, ready: true };
+        }
+        return fallback(false);
+    });
+    const ranRef = useRef(false);
+
+    useEffect(() => {
+        if (ranRef.current || state.ready) return;
+        ranRef.current = true;
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+        const base = apiBase.replace(/\/+$/, "");
+        const url = `${base}/locations/hotspots?disaster_id=${encodeURIComponent(disasterId)}&limit=1`;
+
+        fetch(url, { signal: controller.signal })
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+            .then((data: HotspotsResponse) => {
+                const { lat, lng } = (data.hotspots?.[0] ?? {}) as Hotspot;
+                if (typeof lat === "number" && typeof lng === "number") {
+                    setState({ center: [lat, lng], zoom: HOTSPOT_ZOOM, ready: true });
+                } else setState(fallback(true));
+            })
+            .catch(() => setState(fallback(true)))
+            .finally(() => clearTimeout(timer));
+
+        return () => {
+            clearTimeout(timer);
+            controller.abort();
+        };
+    }, [apiBase, disasterId, state.ready]);
+
+    return state;
+}

--- a/src/hooks/useInitialViewport.ts
+++ b/src/hooks/useInitialViewport.ts
@@ -49,11 +49,17 @@ export function useInitialViewport(
         const url = `${base}/locations/hotspots?disaster_id=${encodeURIComponent(disasterId)}&limit=1`;
 
         fetch(url, { signal: controller.signal })
-            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+            .then((r) =>
+                r.ok ? r.json() : Promise.reject(new Error(`${r.status}`)),
+            )
             .then((data: HotspotsResponse) => {
                 const { lat, lng } = (data.hotspots?.[0] ?? {}) as Hotspot;
                 if (typeof lat === "number" && typeof lng === "number") {
-                    setState({ center: [lat, lng], zoom: HOTSPOT_ZOOM, ready: true });
+                    setState({
+                        center: [lat, lng],
+                        zoom: HOTSPOT_ZOOM,
+                        ready: true,
+                    });
                 } else setState(fallback(true));
             })
             .catch(() => setState(fallback(true)))

--- a/src/lib/viewportStorage.ts
+++ b/src/lib/viewportStorage.ts
@@ -1,0 +1,40 @@
+export interface StoredViewport {
+    center: [number, number];
+    zoom: number;
+    ts: number;
+}
+const STORAGE_KEY = "utd.lastViewport.v1";
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const isNum = (v: unknown): v is number =>
+    typeof v === "number" && Number.isFinite(v);
+
+export function loadViewport(): StoredViewport | null {
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const p = JSON.parse(raw) as Partial<StoredViewport> | null;
+        if (!p || typeof p !== "object") return null;
+        const { center, zoom, ts } = p;
+        if (
+            !Array.isArray(center) ||
+            center.length !== 2 ||
+            !isNum(center[0]) ||
+            !isNum(center[1]) ||
+            !isNum(zoom) ||
+            !isNum(ts)
+        )
+            return null;
+        if (Date.now() - ts > MAX_AGE_MS) return null;
+        return { center: [center[0], center[1]], zoom, ts };
+    } catch {
+        /* parse error or storage denied — treat as no stored viewport */
+        return null;
+    }
+}
+export function saveViewport(v: StoredViewport): void {
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+    } catch {
+        /* blocked storage — noop */
+    }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -242,7 +242,7 @@ const Dashboard = () => {
         const url = `${base.replace(/\/+$/, "")}/locations?${params.toString()}`;
         const controller = new AbortController();
 
-        setIsLoadingLocations(true);
+        queueMicrotask(() => setIsLoadingLocations(true));
         fetch(url, { signal: controller.signal })
             .then((r) =>
                 r.ok ? r.json() : Promise.reject(new Error(`${r.status}`)),

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,8 @@ import ChatDock, { type ChatAction } from "@components/chat/ChatDock";
 import { getChatRuntimeConfig } from "@components/chat/config";
 import { useBoundsCache } from "../hooks/useBoundsCache";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
+import { useInitialViewport } from "../hooks/useInitialViewport";
+import { saveViewport } from "../lib/viewportStorage";
 import ControlPanel, {
     type ImageOverlayMode,
     type LocationToggleState,
@@ -354,6 +356,17 @@ const Dashboard = () => {
 
     const debouncedSetViewport = useDebouncedCallback(setViewport, 300);
 
+    const { apiBaseUrl } = getChatRuntimeConfig();
+    const apiBase = apiBaseUrl || API_BASE_FALLBACK;
+    const initialViewport = useInitialViewport(apiBase, "hurricane-florence");
+
+    const debouncedSaveViewport = useDebouncedCallback(
+        (center: [number, number], zoom: number) => {
+            saveViewport({ center, zoom, ts: Date.now() });
+        },
+        2000,
+    );
+
     const visiblePolygons = polygons.filter((polygon) => {
         const key = normalizeClassification(polygon.classification ?? null);
         return locationToggles[key];
@@ -370,15 +383,23 @@ const Dashboard = () => {
                         />
                     }
                 >
-                    <MapView
-                        imageOverlayMode={imageOverlayMode}
-                        imageOverlayOpacity={imageOverlayOpacity}
-                        isLoading={isLoadingLocations}
-                        polygons={visiblePolygons}
-                        onViewportChange={debouncedSetViewport}
-                        disablePolygons={disableAllArtifacts}
-                        flyTarget={flyTarget}
-                    />
+                    {!initialViewport.ready && (
+                        <div className="h-full w-full animate-pulse bg-slate-300" />
+                    )}
+                    {initialViewport.ready && (
+                        <MapView
+                            imageOverlayMode={imageOverlayMode}
+                            imageOverlayOpacity={imageOverlayOpacity}
+                            isLoading={isLoadingLocations}
+                            polygons={visiblePolygons}
+                            onViewportChange={debouncedSetViewport}
+                            disablePolygons={disableAllArtifacts}
+                            flyTarget={flyTarget}
+                            initialCenter={initialViewport.center}
+                            initialZoom={initialViewport.zoom}
+                            onViewportSettle={debouncedSaveViewport}
+                        />
+                    )}
                 </ErrorBoundary>
             </div>
 


### PR DESCRIPTION
Closes #47 and #49. Pairs with UTDisaster/backend#67.

Two linked improvements to the dashboard. Ships behind graceful fallbacks so this can merge before the backend endpoints land.

## What is new
### Smart default viewport (#47)
On app boot the viewport is resolved in this order:
1. Restore a viewport the user had open in the last 7 days from localStorage (key `utd.lastViewport.v1`).
2. Fetch `/locations/hotspots?disaster_id=hurricane-florence&limit=1` with a 3 second abort timeout, use the first returned bin at zoom 16.
3. Fall back to the previous hardcoded offshore default.

After every pan or zoom the current viewport is saved back to localStorage on a 2 second debounce.

While the hotspot fetch is in flight (0 to 3 seconds), a pulsing slate placeholder fills the map area so users never see a blank gray void.

### Full Florence summary panel (#49)
`DisasterInfoPanel` now fetches `/disasters/hurricane-florence/summary` and renders the dataset-wide description instead of the old Myrtle-only hardcoded paragraph. If the endpoint is not deployed yet, the panel shows "Summary unavailable." and keeps working.

## What is NOT in this PR
- No new npm dependencies.
- No retries or backoff on the fetches.
- No frontend tests (the project has no harness).
- Sidebar dropdown label "Hurricane — Myrtle Beach, SC" is intentionally left alone (out of scope for these two issues).

## Test plan
- [ ] Clear localStorage, reload the app with the backend running. Map opens centered on a real damage cluster, not on water.
- [ ] Pan or zoom, wait 2 seconds, reload. Map opens at the same place (localStorage kicked in).
- [ ] Set localStorage `utd.lastViewport.v1` to a `ts` older than 7 days. Reload. Stored viewport is ignored and the hotspot fetch runs.
- [ ] Stop the backend, clear localStorage, reload. After the 3 second timeout the map falls back to the hardcoded default without crashing.
- [ ] Open the disaster info panel with the backend running. Description comes from `/disasters/{id}/summary`, not a hardcoded Myrtle string.
- [ ] Stop the backend, reload, open the panel. See "Summary unavailable." instead of a crash.