### PR TITLE
feat: chat knows which disaster is currently selected (#48)

### DIFF
--- a/src/components/chat/ChatDock.tsx
+++ b/src/components/chat/ChatDock.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { ViewportBBox } from '@components/map/MapView';
 
 import ChatPanel from './ChatPanel';
+import type { DisasterContext } from './types';
 
 export interface ChatAction {
     type: "flyTo" | "setOpacity" | "setOverlayMode" | "setFilters";
@@ -15,17 +16,27 @@ export interface ChatAction {
     [key: string]: unknown;
 }
 
+export type { DisasterContext };
+
 interface ChatDockProps {
     viewport: ViewportBBox | null;
     onAction?: (action: ChatAction) => void;
+    disasterContext?: DisasterContext;
 }
 
-const ChatDock = ({ viewport, onAction }: ChatDockProps) => {
+const ChatDock = ({ viewport, onAction, disasterContext }: ChatDockProps) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);
 
     return (
         <div className="absolute bottom-4 right-4 z-[1000] flex flex-col items-end gap-4">
-            {isOpen && <ChatPanel setIsOpen={setIsOpen} viewport={viewport} onAction={onAction} />}
+            {isOpen && (
+                <ChatPanel
+                    setIsOpen={setIsOpen}
+                    viewport={viewport}
+                    onAction={onAction}
+                    disasterContext={disasterContext}
+                />
+            )}
             <button
                 className="grid h-14 w-14 place-items-center rounded-xl
                            bg-slate-950 text-white shadow-md

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -4,6 +4,7 @@ import type { FormEventHandler } from "react";
 import type { ViewportBBox } from "@components/map/MapView";
 
 import type { ChatAction } from "./ChatDock";
+import type { DisasterContext } from "./types";
 import { createChatHistoryClient } from "./clients/history/createChatHistoryClient";
 import { createMockChatHistoryClient } from "./clients/history/mockChatHistoryClient";
 import type { ChatHistoryClient } from "./clients/history/types";
@@ -34,6 +35,7 @@ interface ChatPanelProps {
     setIsOpen: (isOpen: boolean) => void;
     viewport: ViewportBBox | null;
     onAction?: (action: ChatAction) => void;
+    disasterContext?: DisasterContext;
 }
 
 const runtimeConfig = getChatRuntimeConfig();
@@ -125,7 +127,7 @@ const hydrateConversations = async (
     );
 };
 
-const ChatPanel = ({ setIsOpen, viewport, onAction }: ChatPanelProps) => {
+const ChatPanel = ({ setIsOpen, viewport, onAction, disasterContext }: ChatPanelProps) => {
     const [conversations, setConversations] =
         useState<ChatConversation[]>(initialConversations);
     const [activeConversationId, setActiveConversationId] =
@@ -357,6 +359,12 @@ const ChatPanel = ({ setIsOpen, viewport, onAction }: ChatPanelProps) => {
             if (viewport) {
                 body.viewport = viewport;
             }
+            // Additive disaster context -- backend uses these to scope Gemini to the selected disaster.
+            // Field names: disaster_id (slug) + disaster_name (human-readable label).
+            if (disasterContext) {
+                body.disaster_id = disasterContext.id;
+                body.disaster_name = disasterContext.name;
+            }
             fetch(`${apiBaseUrl}/chat/message`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -461,6 +469,10 @@ const ChatPanel = ({ setIsOpen, viewport, onAction }: ChatPanelProps) => {
         setIsHistoryOpen(false);
     };
 
+    const isEmptyChat =
+        effectiveActiveId === NEW_CHAT_ID ||
+        (activeConversation?.messages.length ?? 0) === 0;
+
     return (
         <section
             className="w-[720px]
@@ -483,11 +495,15 @@ const ChatPanel = ({ setIsOpen, viewport, onAction }: ChatPanelProps) => {
                 onCloseHistory={() => setIsHistoryOpen(false)}
                 onSelectConversation={handleSelectConversation}
                 onNewChat={handleNewConversation}
+                disasterContext={disasterContext}
             />
             <ChatMessageList
                 messages={activeConversation?.messages ?? []}
                 listRef={listRef}
                 isThinking={isThinking}
+                isEmptyChat={isEmptyChat}
+                disasterContext={disasterContext}
+                onSuggestedPrompt={(prompt) => setDraft(prompt)}
             />
             <ChatInput
                 draft={draft}

--- a/src/components/chat/components/ChatHeader.tsx
+++ b/src/components/chat/components/ChatHeader.tsx
@@ -1,5 +1,6 @@
-import { History, SquarePen, X } from 'lucide-react';
+import { History, MapPin, SquarePen, X } from 'lucide-react';
 
+import type { DisasterContext } from '../types';
 import type { ChatConversation } from '../types';
 import ChatHistoryMenu from './ChatHistoryMenu';
 
@@ -15,6 +16,7 @@ interface ChatHeaderProps {
     onCloseHistory: () => void;
     onSelectConversation: (conversationId: string) => void;
     onNewChat: () => void;
+    disasterContext?: DisasterContext;
 }
 
 const ChatHeader = ({
@@ -29,6 +31,7 @@ const ChatHeader = ({
     onCloseHistory,
     onSelectConversation,
     onNewChat,
+    disasterContext,
 }: ChatHeaderProps) => {
     return (
         <header className="relative flex items-center justify-between border-b border-slate-900/10 px-5 py-4">
@@ -37,6 +40,12 @@ const ChatHeader = ({
                 <p className="text-xs text-slate-500">
                     {connectionLabel} · {conversationTitle}
                 </p>
+                {disasterContext && (
+                    <p className="flex items-center gap-1 text-xs text-blue-600 mt-0.5">
+                        <MapPin className="h-3 w-3" />
+                        Talking about: {disasterContext.name}
+                    </p>
+                )}
             </div>
             <div className="flex items-center gap-2">
                 <button

--- a/src/components/chat/components/ChatMessageList.tsx
+++ b/src/components/chat/components/ChatMessageList.tsx
@@ -1,12 +1,30 @@
 import type { RefObject } from 'react';
 
+import type { DisasterContext } from '../types';
 import type { ChatMessage } from '../types';
 import ChatBubble from './ChatBubble';
+
+interface SuggestedPrompt {
+    label: string;
+    text: string;
+}
+
+const buildSuggestedPrompts = (disasterContext: DisasterContext | undefined): SuggestedPrompt[] => {
+    const name = disasterContext?.name ?? 'this disaster';
+    return [
+        { label: 'Damage summary', text: `Damage summary for ${name}` },
+        { label: 'Severely damaged buildings', text: 'How many severely damaged buildings are there?' },
+        { label: 'Nearby damage', text: 'Show me damage near the city center' },
+    ];
+};
 
 interface ChatMessageListProps {
     messages: ChatMessage[];
     listRef: RefObject<HTMLDivElement>;
     isThinking?: boolean;
+    isEmptyChat?: boolean;
+    disasterContext?: DisasterContext;
+    onSuggestedPrompt?: (prompt: string) => void;
 }
 
 const ThinkingBubble = () => (
@@ -17,15 +35,63 @@ const ThinkingBubble = () => (
     </div>
 );
 
-const ChatMessageList = ({ messages, listRef, isThinking = false }: ChatMessageListProps) => {
+const EmptyChatState = ({
+    disasterContext,
+    onSuggestedPrompt,
+}: {
+    disasterContext?: DisasterContext;
+    onSuggestedPrompt?: (prompt: string) => void;
+}) => {
+    const prompts = buildSuggestedPrompts(disasterContext);
+    return (
+        <div className="flex flex-col items-center justify-center h-full gap-4 px-4 text-center">
+            <div>
+                <p className="text-sm font-semibold text-slate-700">How can I help?</p>
+                <p className="text-xs text-slate-500 mt-1">
+                    Ask about damage levels, specific addresses, or streets.
+                </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 w-full max-w-md">
+                {prompts.map((prompt) => (
+                    <button
+                        key={prompt.label}
+                        type="button"
+                        onClick={() => onSuggestedPrompt?.(prompt.text)}
+                        className="rounded-lg border border-slate-200 bg-white px-3 py-2
+                                   text-left text-xs text-slate-700 shadow-sm
+                                   transition hover:border-slate-400 hover:bg-slate-50"
+                    >
+                        {prompt.label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+const ChatMessageList = ({
+    messages,
+    listRef,
+    isThinking = false,
+    isEmptyChat = false,
+    disasterContext,
+    onSuggestedPrompt,
+}: ChatMessageListProps) => {
     return (
         <div
             ref={listRef}
             className="flex h-[360px] flex-col gap-3 overflow-y-auto px-4 py-4"
         >
-            {messages.map((message) => (
-                <ChatBubble key={message.id} message={message} />
-            ))}
+            {isEmptyChat && !isThinking ? (
+                <EmptyChatState
+                    disasterContext={disasterContext}
+                    onSuggestedPrompt={onSuggestedPrompt}
+                />
+            ) : (
+                messages.map((message) => (
+                    <ChatBubble key={message.id} message={message} />
+                ))
+            )}
             {isThinking && <ThinkingBubble />}
         </div>
     );

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -19,3 +19,9 @@ export interface ChatConversation {
     updatedAt: string;
     messages: ChatMessage[];
 }
+
+/** Identifies which disaster the user currently has selected in the sidebar. */
+export interface DisasterContext {
+    id: string;
+    name: string;
+}

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -12,6 +12,7 @@ import {
     type ClassificationKey,
     type MapPolygon,
 } from "@components/map/types";
+import { DISASTERS } from "../../data/disasters";
 
 interface DisasterLocation {
     imagePairId: string;
@@ -27,11 +28,9 @@ interface DashboardSidebarProps {
     disasterLocations?: DisasterLocation[];
     currentLocationIndex?: number;
     onLocationNavigate?: (index: number) => void;
+    selectedDisasterId: string;
+    onDisasterChange: (id: string) => void;
 }
-
-const DISASTERS = [
-    { id: "myrtle-beach", label: "Hurricane — Myrtle Beach, SC" },
-];
 
 const CLASSIFICATION_ORDER: ClassificationKey[] = [
     "destroyed",
@@ -79,8 +78,9 @@ const DashboardSidebar = ({
     disasterLocations = [],
     currentLocationIndex = 0,
     onLocationNavigate,
+    selectedDisasterId,
+    onDisasterChange,
 }: DashboardSidebarProps) => {
-    const [selectedDisaster, setSelectedDisaster] = useState(DISASTERS[0].id);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -104,7 +104,7 @@ const DashboardSidebar = ({
     if (!isOpen) return null;
 
     const selected =
-        DISASTERS.find((d) => d.id === selectedDisaster) ?? DISASTERS[0];
+        DISASTERS.find((d) => d.id === selectedDisasterId) ?? DISASTERS[0];
 
     return (
         <>
@@ -159,7 +159,7 @@ const DashboardSidebar = ({
                                 aria-controls="disaster-listbox"
                             >
                                 <span className="truncate">
-                                    {selected.label}
+                                    {selected.name}
                                 </span>
                                 <ChevronDown
                                     className={`h-4 w-4 text-slate-500 transition ${
@@ -180,22 +180,22 @@ const DashboardSidebar = ({
                                             key={d.id}
                                             role="option"
                                             aria-selected={
-                                                d.id === selectedDisaster
+                                                d.id === selectedDisasterId
                                             }
                                         >
                                             <button
                                                 type="button"
                                                 className={`w-full px-3 py-2 text-left text-sm transition hover:bg-slate-100 ${
-                                                    d.id === selectedDisaster
+                                                    d.id === selectedDisasterId
                                                         ? "font-semibold text-blue-600"
                                                         : "text-slate-700"
                                                 }`}
                                                 onClick={() => {
-                                                    setSelectedDisaster(d.id);
+                                                    onDisasterChange(d.id);
                                                     setIsDropdownOpen(false);
                                                 }}
                                             >
-                                                {d.label}
+                                                {d.name}
                                             </button>
                                         </li>
                                     ))}

--- a/src/data/disasters.ts
+++ b/src/data/disasters.ts
@@ -1,0 +1,5 @@
+import type { DisasterContext } from "@components/chat/types";
+
+export const DISASTERS: DisasterContext[] = [
+    { id: "myrtle-beach", name: "Hurricane \u2014 Myrtle Beach, SC" },
+];

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import ChatDock, { type ChatAction } from "@components/chat/ChatDock";
+import { DISASTERS } from "../data/disasters";
 import { getChatRuntimeConfig } from "@components/chat/config";
 import { useBoundsCache } from "../hooks/useBoundsCache";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
@@ -183,6 +184,10 @@ const Dashboard = () => {
     const { reportFetchSuccess, reportFetchFailure } =
         useBackendStatusContext();
     const backend = useBackendStatus();
+    const [selectedDisasterId, setSelectedDisasterId] = useState<string>(DISASTERS[0].id);
+
+    const selectedDisasterContext =
+        DISASTERS.find((d) => d.id === selectedDisasterId) ?? DISASTERS[0];
 
     const VALID_OVERLAY_MODES: ReadonlySet<ImageOverlayMode> = new Set([
         "pre",
@@ -464,8 +469,10 @@ const Dashboard = () => {
                 disasterLocations={disasterLocations}
                 currentLocationIndex={currentLocationIndex}
                 onLocationNavigate={handleLocationNavigate}
+                selectedDisasterId={selectedDisasterId}
+                onDisasterChange={setSelectedDisasterId}
             />
-            <ChatDock viewport={viewport} onAction={handleChatAction} />
+            <ChatDock viewport={viewport} onAction={handleChatAction} disasterContext={selectedDisasterContext} />
             <DisasterInfoPanel
                 isOpen={isDisasterInfoOpen}
                 onClose={() => setIsDisasterInfoOpen(false)}


### PR DESCRIPTION
Closes #48.

## What this does, in plain English

Before this change, the chat on the dashboard had no idea *which* disaster the user was currently looking at. You could be staring at Hurricane Florence damage tiles and the chat would happily answer questions as if you were asking about a generic dataset.

Now the chat knows. Two things happen:

1. **The chat header shows a "Talking about: Hurricane -- Myrtle Beach, SC" pill** so it's obvious what the chat is scoped to.
2. **Every message you send to the backend includes the disaster's id and display name**, so the Gemini agent on the backend can ground its answers in the right disaster. If you switch disasters in the sidebar (once we have more than one seeded), the chat header and every subsequent question update together.

There are also **three suggested prompts in the empty chat state** so new users have a place to start. The first one uses the disaster's name automatically -- no hardcoded "Florence".

## Why it was structured this way

- **Single source of truth for the disasters list** (`src/data/disasters.ts`). Both the sidebar and the dashboard import from it, so adding a new disaster is a one-file change. No more risk of the sidebar label and the chat header label drifting apart.
- **State lifted to `Dashboard.tsx`**. The sidebar used to own the selected-disaster value privately, which meant the chat couldn't see it. I moved the state up one level so the sidebar and the chat are reading the same variable.
- **Additive POST fields** (`disaster_id`, `disaster_name`). The current deployed backend doesn't know about these fields yet -- that's fine, it'll just ignore them. Backend PR #68 is the one that will actually use them.

## What this does NOT do

- No backend work. That's in backend PR #68 (disaster summary endpoint) and PR #70 (address-aware tools).
- No change to how flyTo/navigate actions are handled -- those were already wired up in an earlier PR.
- No new npm dependencies.
- Doesn't address address/street awareness -- that's the follow-up PR stacked on top of this one.

## Test plan

- [x] `npm run build` passes (tsc -b + vite build clean)
- [x] Dev server smoke test: opened chat, confirmed "Talking about:" pill renders
- [x] Playwright E2E confirmed `disaster_id` + `disaster_name` appear in the POST body
- [x] Clicking a suggested prompt populates the input
- [x] Sidebar dropdown still opens/closes correctly
- [ ] Will fully activate once backend PR #68 lands and prod picks up the new fields