### PR TITLE
feat: chat understands addresses and streets (#51)

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -389,11 +389,14 @@ const ChatPanel = ({ setIsOpen, viewport, onAction, disasterContext }: ChatPanel
                         actions?: ChatAction[];
                     }) => {
                         backendConversationIdRef.current = data.conversation_id;
+                        const hasFlyTo = Array.isArray(data.actions) &&
+                            data.actions.some((a) => a.type === "flyTo");
                         const agentMessage: ChatMessage = {
                             id: createMessageId("agent"),
                             sender: "agent",
                             text: data.reply,
                             sentAt: new Date().toISOString(),
+                            hasFlyTo,
                         };
                         setConversations((current) =>
                             appendMessageToConversation(

--- a/src/components/chat/components/ChatBubble.tsx
+++ b/src/components/chat/components/ChatBubble.tsx
@@ -1,3 +1,5 @@
+import { MapPin } from 'lucide-react';
+
 import { formatMessageTime } from '../util';
 import type { ChatMessage } from '../types';
 
@@ -18,6 +20,12 @@ const ChatBubble = ({ message }: ChatBubbleProps) => {
                 }`}
             >
                 <p className="text-sm leading-relaxed">{message.text}</p>
+                {message.hasFlyTo && (
+                    <p className="mt-1.5 flex items-center gap-1 text-xs text-blue-600">
+                        <MapPin className="h-3 w-3" />
+                        Map moved to this location
+                    </p>
+                )}
                 <p
                     className={`mt-1 text-xs ${
                         isUser ? 'text-slate-300' : 'text-slate-500'

--- a/src/components/chat/components/ChatInput.tsx
+++ b/src/components/chat/components/ChatInput.tsx
@@ -39,7 +39,7 @@ const ChatInput = ({ draft, onDraftChange, onSend }: ChatInputProps) => {
                             event.currentTarget.form?.requestSubmit();
                         }
                     }}
-                    placeholder="Type your message..."
+                    placeholder="Ask about damage levels, addresses, or streets..."
                     rows={1}
                     className="w-full resize-none bg-transparent py-1 text-sm leading-5 text-slate-900 outline-none placeholder:text-slate-400"
                 />

--- a/src/components/chat/components/ChatMessageList.tsx
+++ b/src/components/chat/components/ChatMessageList.tsx
@@ -14,6 +14,7 @@ const buildSuggestedPrompts = (disasterContext: DisasterContext | undefined): Su
     return [
         { label: 'Damage summary', text: `Damage summary for ${name}` },
         { label: 'Severely damaged buildings', text: 'How many severely damaged buildings are there?' },
+        { label: 'Damage on a specific street', text: 'Buildings damaged on a specific street?' },
         { label: 'Nearby damage', text: 'Show me damage near the city center' },
     ];
 };

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -11,6 +11,8 @@ export interface ChatMessage {
     sender: Sender;
     text: string;
     sentAt: string;
+    /** True when the agent response triggered a map flyTo action. */
+    hasFlyTo?: boolean;
 }
 
 export interface ChatConversation {


### PR DESCRIPTION
Closes #51. **Stacks on #64** (please merge #64 first; this PR targets that branch).

## What this does, in plain English

Now that the backend (PR #70) can answer questions like "what damage happened on Ocean Boulevard?" or "what's torn up near downtown?", the chat UI needs to actually *nudge* users toward asking those kinds of questions -- and react nicely when the backend's answer wants to move the map.

Three small touches:

1. **The placeholder in the chat box now says "Ask about damage levels, addresses, or streets..."** so the user realizes they can ask about specific places, not just generic stats.
2. **A fourth suggested prompt appears on the empty chat state** -- "Damage on a specific street" -- so new users have an obvious on-ramp.
3. **When the backend reply includes a map flyTo action** (the new address-lookup tool embeds one when it's very confident it knows the exact place you asked about), the chat bubble shows a small "Map moved to this location" note under the text so the user understands why the map just jumped.

## Why it was structured this way

- The existing flyTo handler from a previous PR already does the actual map panning. This PR does not re-implement anything -- it just adds the visual confirmation in the bubble.
- The bubble affordance is driven by a new optional `hasFlyTo` field on `ChatMessage`. It's only set when the response actually contains a flyTo action, so there are no false positives.
- The suggested prompt wording is generic ("a specific street") rather than hardcoding "Ocean Boulevard" or any Myrtle Beach landmark, so it stays sensible if/when we seed more disasters.

## What this does NOT do

- No new fuzzy-matching or address logic on the frontend. All of that lives in backend PR #70 via `pg_trgm`.
- No change to the flyTo map-panning itself -- still handled by the existing action dispatcher.
- No new npm dependencies.

## Deploy gate

For the flyTo affordance to actually appear in production, all of these need to be live:
1. Backend PR #66 (address columns) merged and migrated on prod Supabase
2. Backend PR #69 (pg_trgm indexes) merged and migrated on prod Supabase
3. Backend PR #70 (address chat tools) merged
4. `util/enrich_addresses.py` has run for the demo area on prod

Without those, the backend still replies to address-style questions, it just won't embed flyTo actions, so the bubble never shows the "Map moved to this location" line. That's a graceful no-op, not a regression.

## Test plan

- [x] `npm run build` passes (tsc -b + vite build clean)
- [x] Empty chat state shows the new "Damage on a specific street" prompt
- [x] Placeholder wording includes "addresses" / "streets"
- [ ] End-to-end flyTo affordance once backend PR #70 is deployed to prod