### PR TITLE
fix: align disaster id with backend (hurricane-florence) (#49)

### DIFF
--- a/src/data/disasters.ts
+++ b/src/data/disasters.ts
@@ -1,5 +1,5 @@
 import type { DisasterContext } from "@components/chat/types";
 
 export const DISASTERS: DisasterContext[] = [
-    { id: "myrtle-beach", name: "Hurricane \u2014 Myrtle Beach, SC" },
+    { id: "hurricane-florence", name: "Hurricane Florence" },
 ];


### PR DESCRIPTION
Closes #49.

## What this fixes, in plain English

Two bugs in one line.

1. **Menu label says "Myrtle Beach" when it should say "Florence".** The sidebar dropdown and the chat's "Talking about:" pill both displayed `Hurricane — Myrtle Beach, SC`. Myrtle Beach is just one of the populated areas in the dataset — the actual disaster is Hurricane Florence. Issue #49 called this out specifically.
2. **The chat was sending the wrong disaster id to the backend.** Since FE #64 merged, every chat POST has been sending `disaster_id=myrtle-beach`. But the backend's entire pipeline uses `hurricane-florence` as the canonical id — it appears in `preprocess-data.py`, `seed_minimal.py`, Gemini tool schemas, and the seeded `image_pairs.disaster_id` column. Result: any Gemini tool call that filters by disaster id has been silently returning zero rows instead of the real scoped results.

## The change

One line in `src/data/disasters.ts`:
```diff
-    { id: "myrtle-beach", name: "Hurricane \u2014 Myrtle Beach, SC" },
+    { id: "hurricane-florence", name: "Hurricane Florence" },
```

The `DisasterContext` type is reused by the chat header, empty-state suggested prompts, and the POST body, so this single edit ripples through all of them correctly.

## Not in this PR

- No backend changes (the backend id was always correct — this PR just aligns the frontend to it).
- No change to the damage stats in `DisasterInfoPanel`, which still derive from the polygons loaded in the current viewport (that's a data-seeding concern tracked separately, not what #49 was asking for).

## Test plan

- [x] `npm run build` passes (tsc -b + vite build clean)
- [ ] After merge, verify the chat header pill reads "Talking about: Hurricane Florence" and the suggested prompt interpolates "Damage summary for Hurricane Florence"
- [ ] After merge, verify the chat POST body in devtools shows `disaster_id: "hurricane-florence"`